### PR TITLE
Move from httpsync to http-sync

### DIFF
--- a/lib/Http.js
+++ b/lib/Http.js
@@ -6,7 +6,7 @@ var parse_url = require('url').parse;
 
 try {
     __WINDOWS = !!process.platform.match(/^win/);
-    httpsync = require('httpsync');
+    httpsync = require('http-sync');
 } catch (e) {
     if ((e.code === 'MODULE_NOT_FOUND') && __WINDOWS) {
         httpsync = require('http-sync-win');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "should": ">= 3.0.x"
     },
     "optionalDependencies": {
-        "httpsync": ">= 0.0.8",
+        "http-sync": "0.1.2",
         "http-sync-win": ">=0.0.7"
     },
     "devDependencies": {


### PR DESCRIPTION
httpsync (https://github.com/fengmk2/node-curl) has been discontinued, as previously noted in issue #7. 

A satisfactory solution for us has been substituting with http-sync (https://github.com/dhruvbird/http-sync).
